### PR TITLE
TH-785 | Change CMS image field structure

### DIFF
--- a/src/schema/collection/typeDefs.ts
+++ b/src/schema/collection/typeDefs.ts
@@ -26,7 +26,7 @@ const typeDefs = gql`
     firstPublishedAt: String
     goLiveAt: String
     hasUnpublishedChanges: Boolean
-    heroImage: String
+    heroImage: CmsImage
     lastPublishedAt: String
     latestRevisionCreatedAt: String
     linkText: LocalizedObject

--- a/src/schema/global/typeDefs/index.ts
+++ b/src/schema/global/typeDefs/index.ts
@@ -31,6 +31,21 @@ export const LocalizedObject = gql`
   }
 `;
 
+export const CmsImage = gql`
+  type CmsImage {
+    photographerCredit: String
+    url: String
+  }
+`;
+
+export const LocalizedCmsImage = gql`
+  type LocalizedCmsImage {
+    url: CmsImage
+    sv: CmsImage
+    en: CmsImage
+  }
+`;
+
 export const Meta = gql`
   type Meta {
     count: Int!
@@ -40,7 +55,9 @@ export const Meta = gql`
 `;
 
 const global = [
+  CmsImage,
   InternalIdObject,
+  LocalizedCmsImage,
   LocalizedObject,
   Meta,
   Mutation,

--- a/src/schema/global/typeDefs/index.ts
+++ b/src/schema/global/typeDefs/index.ts
@@ -40,9 +40,9 @@ export const CmsImage = gql`
 
 export const LocalizedCmsImage = gql`
   type LocalizedCmsImage {
-    url: CmsImage
-    sv: CmsImage
     en: CmsImage
+    fi: CmsImage
+    sv: CmsImage
   }
 `;
 

--- a/src/schema/landingPage/typeDefs.ts
+++ b/src/schema/landingPage/typeDefs.ts
@@ -37,11 +37,11 @@ const typeDefs = gql`
     descriptionColor: LocalizedObject
     buttonText: LocalizedObject
     buttonUrl: LocalizedObject
-    heroBackgroundImage: LocalizedObject
-    heroBackgroundImageMobile: LocalizedObject
+    heroBackgroundImage: LocalizedCmsImage
+    heroBackgroundImageMobile: LocalizedCmsImage
     heroBackgroundImageColor: LocalizedObject
-    heroTopLayerImage: LocalizedObject
-    socialMediaImage: LocalizedObject
+    heroTopLayerImage: LocalizedCmsImage
+    socialMediaImage: LocalizedCmsImage
     metaInformation: LocalizedObject
     pageTitle: LocalizedObject
     contentType: Int

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -230,9 +230,9 @@ export type LandingPageResponse = {
 
 export type LocalizedCmsImage = {
    __typename?: 'LocalizedCmsImage',
-  url?: Maybe<CmsImage>,
-  sv?: Maybe<CmsImage>,
   en?: Maybe<CmsImage>,
+  fi?: Maybe<CmsImage>,
+  sv?: Maybe<CmsImage>,
 };
 
 export type LocalizedObject = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -8,6 +8,12 @@ export type Scalars = {
   Float: number,
 };
 
+export type CmsImage = {
+   __typename?: 'CmsImage',
+  photographerCredit?: Maybe<Scalars['String']>,
+  url?: Maybe<Scalars['String']>,
+};
+
 export type CollectionDetails = {
    __typename?: 'CollectionDetails',
   id: Scalars['ID'],
@@ -25,7 +31,7 @@ export type CollectionDetails = {
   firstPublishedAt?: Maybe<Scalars['String']>,
   goLiveAt?: Maybe<Scalars['String']>,
   hasUnpublishedChanges?: Maybe<Scalars['Boolean']>,
-  heroImage?: Maybe<Scalars['String']>,
+  heroImage?: Maybe<CmsImage>,
   lastPublishedAt?: Maybe<Scalars['String']>,
   latestRevisionCreatedAt?: Maybe<Scalars['String']>,
   linkText?: Maybe<LocalizedObject>,
@@ -204,11 +210,11 @@ export type LandingPage = {
   descriptionColor?: Maybe<LocalizedObject>,
   buttonText?: Maybe<LocalizedObject>,
   buttonUrl?: Maybe<LocalizedObject>,
-  heroBackgroundImage?: Maybe<LocalizedObject>,
-  heroBackgroundImageMobile?: Maybe<LocalizedObject>,
+  heroBackgroundImage?: Maybe<LocalizedCmsImage>,
+  heroBackgroundImageMobile?: Maybe<LocalizedCmsImage>,
   heroBackgroundImageColor?: Maybe<LocalizedObject>,
-  heroTopLayerImage?: Maybe<LocalizedObject>,
-  socialMediaImage?: Maybe<LocalizedObject>,
+  heroTopLayerImage?: Maybe<LocalizedCmsImage>,
+  socialMediaImage?: Maybe<LocalizedCmsImage>,
   metaInformation?: Maybe<LocalizedObject>,
   pageTitle?: Maybe<LocalizedObject>,
   contentType?: Maybe<Scalars['Int']>,
@@ -220,6 +226,13 @@ export type LandingPage = {
 export type LandingPageResponse = {
    __typename?: 'LandingPageResponse',
   data: Array<LandingPage>,
+};
+
+export type LocalizedCmsImage = {
+   __typename?: 'LocalizedCmsImage',
+  url?: Maybe<CmsImage>,
+  sv?: Maybe<CmsImage>,
+  en?: Maybe<CmsImage>,
 };
 
 export type LocalizedObject = {

--- a/src/utils/__tests__/normalizeLocalizedObject.test.ts
+++ b/src/utils/__tests__/normalizeLocalizedObject.test.ts
@@ -24,5 +24,45 @@ describe('normalizeLocalizedObject function', () => {
         sv: 'title sv',
       },
     });
+    expect(
+      normalizeLocalizedObject(
+        {
+          eventPrice: {
+            isFree: false,
+          },
+          eventType: 'foo',
+          imageEn: {
+            name: 'title en',
+            url: 'www.test.en',
+          },
+          imageFi: {
+            name: 'title fi',
+            url: 'www.test.fi',
+          },
+          imageSv: {
+            name: 'title sv',
+            url: 'www.test.sv',
+          },
+        },
+        'image'
+      )
+    ).toEqual({
+      eventPrice: { isFree: false },
+      eventType: 'foo',
+      image: {
+        en: {
+          name: 'title en',
+          url: 'www.test.en',
+        },
+        fi: {
+          name: 'title fi',
+          url: 'www.test.fi',
+        },
+        sv: {
+          name: 'title sv',
+          url: 'www.test.sv',
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
## Description
Change CMS image to be an object and add url and photographer_credit fields inside it

## Closes
**[TH-785](https://helsinkisolutionoffice.atlassian.net/browse/TH-785)**