### PR TITLE
TH-911 | Update top and banner of LandingPages, add hobbyListQuery to Collections

### DIFF
--- a/src/schema/collection/resolvers.ts
+++ b/src/schema/collection/resolvers.ts
@@ -14,6 +14,7 @@ const normalizeCollection = (collection) => {
     'socialMediaDescription',
     'curatedEventsTitle',
     'eventListQuery',
+    'courseListQuery',
     'eventListTitle',
   ];
 

--- a/src/schema/collection/typeDefs.ts
+++ b/src/schema/collection/typeDefs.ts
@@ -20,6 +20,7 @@ const typeDefs = gql`
     description: LocalizedObject
     draftTitle: String
     eventListQuery: LocalizedObject
+    courseListQuery: LocalizedObject
     eventListTitle: LocalizedObject
     expireAt: String
     expired: Boolean

--- a/src/schema/global/typeDefs/index.ts
+++ b/src/schema/global/typeDefs/index.ts
@@ -102,6 +102,22 @@ export const Enums = gql`
   }
 `;
 
+export const BannerPage = gql`
+  type BannerPage {
+    title: LocalizedObject
+    description: LocalizedObject
+    keywords: LocalizedCmsKeywords
+    titleAndDescriptionColor: LocalizedObject
+    buttonText: LocalizedObject
+    buttonUrl: LocalizedObject
+    heroBackgroundImage: LocalizedCmsImage
+    heroBackgroundImageMobile: LocalizedCmsImage
+    heroBackgroundImageColor: LocalizedObject
+    heroTopLayerImage: LocalizedCmsImage
+    socialMediaImage: LocalizedCmsImage
+  }
+`;
+
 const globalDefs = [
   CmsImage,
   InternalIdObject,
@@ -112,6 +128,7 @@ const globalDefs = [
   Mutation,
   Query,
   StaticPage,
+  BannerPage,
   Subscription,
   Enums,
 ];

--- a/src/schema/landingPage/resolvers.ts
+++ b/src/schema/landingPage/resolvers.ts
@@ -7,7 +7,10 @@ const normalizeLandingPage = (collection) => {
   let normalizedLandingPage = normalizeKeys(collection);
   const normalizedKeys = [
     'title',
+
+    // BEGIN deprecated fields
     'description',
+    'socialMediaImage',
     'titleAndDescriptionColor',
     'buttonText',
     'buttonUrl',
@@ -15,19 +18,58 @@ const normalizeLandingPage = (collection) => {
     'heroBackgroundImageMobile',
     'heroBackgroundImageColor',
     'heroTopLayerImage',
+    // END deprecated fields
+
     'keywords',
-    'socialMediaImage',
     'metaInformation',
     'pageTitle',
+    {
+      bottomBanner: [
+        'title',
+        'description',
+        'titleAndDescriptionColor',
+        'buttonText',
+        'buttonUrl',
+        'heroBackgroundImage',
+        'heroBackgroundImageMobile',
+        'heroBackgroundImageColor',
+        'heroTopLayerImage',
+        'socialMediaImage',
+      ],
+    },
+    {
+      topBanner: [
+        'title',
+        'description',
+        'titleAndDescriptionColor',
+        'buttonText',
+        'buttonUrl',
+        'heroBackgroundImage',
+        'heroBackgroundImageMobile',
+        'heroBackgroundImageColor',
+        'heroTopLayerImage',
+        'socialMediaImage',
+      ],
+    },
   ];
 
   normalizedKeys.forEach((item) => {
-    normalizedLandingPage = normalizeLocalizedObject(
-      normalizedLandingPage,
-      item
-    );
+    if (typeof item === 'string') {
+      normalizedLandingPage = normalizeLocalizedObject(
+        normalizedLandingPage,
+        item
+      );
+    } else if (typeof item === 'object') {
+      Object.entries(item).forEach(([nestedFieldName, nestedFields]) => {
+        nestedFields.forEach((localizeObject) => {
+          normalizedLandingPage[nestedFieldName] = normalizeLocalizedObject(
+            normalizedLandingPage[nestedFieldName],
+            localizeObject
+          );
+        });
+      });
+    }
   });
-
   return normalizedLandingPage;
 };
 

--- a/src/schema/landingPage/resolvers.ts
+++ b/src/schema/landingPage/resolvers.ts
@@ -23,52 +23,13 @@ const normalizeLandingPage = (collection) => {
     'keywords',
     'metaInformation',
     'pageTitle',
-    {
-      bottomBanner: [
-        'title',
-        'description',
-        'titleAndDescriptionColor',
-        'buttonText',
-        'buttonUrl',
-        'heroBackgroundImage',
-        'heroBackgroundImageMobile',
-        'heroBackgroundImageColor',
-        'heroTopLayerImage',
-        'socialMediaImage',
-      ],
-    },
-    {
-      topBanner: [
-        'title',
-        'description',
-        'titleAndDescriptionColor',
-        'buttonText',
-        'buttonUrl',
-        'heroBackgroundImage',
-        'heroBackgroundImageMobile',
-        'heroBackgroundImageColor',
-        'heroTopLayerImage',
-        'socialMediaImage',
-      ],
-    },
   ];
 
   normalizedKeys.forEach((item) => {
-    if (typeof item === 'string') {
       normalizedLandingPage = normalizeLocalizedObject(
         normalizedLandingPage,
         item
       );
-    } else if (typeof item === 'object') {
-      Object.entries(item).forEach(([nestedFieldName, nestedFields]) => {
-        nestedFields.forEach((localizeObject) => {
-          normalizedLandingPage[nestedFieldName] = normalizeLocalizedObject(
-            normalizedLandingPage[nestedFieldName],
-            localizeObject
-          );
-        });
-      });
-    }
   });
   return normalizedLandingPage;
 };

--- a/src/schema/landingPage/typeDefs.ts
+++ b/src/schema/landingPage/typeDefs.ts
@@ -12,6 +12,8 @@ const typeDefs = gql`
 
   type LandingPage {
     id: ID!
+    topBanner: BannerPage
+    bottomBanner: BannerPage
     path: String
     depth: Int
     numchild: Int

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,6 +20,7 @@ export type AccessibilityPagesResponse = {
   data: Array<StaticPage>,
 };
 
+
 export type Audience = {
    __typename?: 'Audience',
   id?: Maybe<Scalars['ID']>,
@@ -27,6 +28,22 @@ export type Audience = {
   internalId?: Maybe<Scalars['String']>,
   internalContext?: Maybe<Scalars['String']>,
   internalType?: Maybe<Scalars['String']>,
+};
+
+export type BannerPage = {
+   __typename?: 'BannerPage',
+  title?: Maybe<LocalizedObject>,
+  description?: Maybe<LocalizedObject>,
+  keywords?: Maybe<LocalizedCmsKeywords>,
+  titleAndDescriptionColor?: Maybe<LocalizedObject>,
+  buttonText?: Maybe<LocalizedObject>,
+  buttonUrl?: Maybe<LocalizedObject>,
+  heroBackgroundImage?: Maybe<LocalizedCmsImage>,
+  heroBackgroundImageMobile?: Maybe<LocalizedCmsImage>,
+  heroBackgroundImageColor?: Maybe<LocalizedObject>,
+  heroTopLayerImage?: Maybe<LocalizedCmsImage>,
+  socialMediaImage?: Maybe<LocalizedCmsImage>,
+
 };
 
 export type CmsImage = {
@@ -207,6 +224,8 @@ export type KeywordListResponse = {
 export type LandingPage = {
    __typename?: 'LandingPage',
   id: Scalars['ID'],
+  topBanner?: Maybe<BannerPage>,
+  bottomBanner?: Maybe<BannerPage>,
   path?: Maybe<Scalars['String']>,
   depth?: Maybe<Scalars['Int']>,
   numchild?: Maybe<Scalars['Int']>,
@@ -695,6 +714,7 @@ export type ResolversTypes = {
   LinkedEventsSource: LinkedEventsSource;
   KeywordListResponse: ResolverTypeWrapper<KeywordListResponse>;
   LandingPage: ResolverTypeWrapper<LandingPage>;
+  BannerPage: ResolverTypeWrapper<BannerPage>;
   LocalizedCmsImage: ResolverTypeWrapper<LocalizedCmsImage>;
   LandingPagesResponse: ResolverTypeWrapper<LandingPagesResponse>;
   NeighborhoodListResponse: ResolverTypeWrapper<NeighborhoodListResponse>;
@@ -737,6 +757,7 @@ export type ResolversParentTypes = {
   Meta: Meta;
   KeywordListResponse: KeywordListResponse;
   LandingPage: LandingPage;
+  BannerPage: BannerPage;
   LocalizedCmsImage: LocalizedCmsImage;
   LandingPagesResponse: LandingPagesResponse;
   NeighborhoodListResponse: NeighborhoodListResponse;
@@ -757,12 +778,27 @@ export type AccessibilityPagesResponseResolvers<ContextType = any, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+<<<<<<< HEAD
 export type AudienceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Audience'] = ResolversParentTypes['Audience']> = {
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   internalId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   internalContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   internalType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+=======
+export type BannerPageResolvers<ContextType = any, ParentType extends ResolversParentTypes['BannerPage'] = ResolversParentTypes['BannerPage']> = {
+  title?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  keywords?: Resolver<Maybe<ResolversTypes['LocalizedCmsKeywords']>, ParentType, ContextType>;
+  titleAndDescriptionColor?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  buttonText?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  buttonUrl?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  heroBackgroundImage?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
+  heroBackgroundImageMobile?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
+  heroBackgroundImageColor?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  heroTopLayerImage?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
+  socialMediaImage?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
+>>>>>>> bbe37fd... Add top and bottom banner to LandingPage
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -943,6 +979,8 @@ export type KeywordListResponseResolvers<ContextType = any, ParentType extends R
 
 export type LandingPageResolvers<ContextType = any, ParentType extends ResolversParentTypes['LandingPage'] = ResolversParentTypes['LandingPage']> = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  topBanner?: Resolver<Maybe<ResolversTypes['BannerPage']>, ParentType, ContextType>;
+  bottomBanner?: Resolver<Maybe<ResolversTypes['BannerPage']>, ParentType, ContextType>;
   path?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   depth?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   numchild?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -1165,7 +1203,11 @@ export type SubscriptionResolvers<ContextType = any, ParentType extends Resolver
 export type Resolvers<ContextType = any> = {
   AboutPagesResponse?: AboutPagesResponseResolvers<ContextType>;
   AccessibilityPagesResponse?: AccessibilityPagesResponseResolvers<ContextType>;
+<<<<<<< HEAD
   Audience?: AudienceResolvers<ContextType>;
+=======
+  BannerPage?: BannerPageResolvers<ContextType>;
+>>>>>>> bbe37fd... Add top and bottom banner to LandingPage
   CmsImage?: CmsImageResolvers<ContextType>;
   CollectionDetails?: CollectionDetailsResolvers<ContextType>;
   CollectionListResponse?: CollectionListResponseResolvers<ContextType>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,7 +20,6 @@ export type AccessibilityPagesResponse = {
   data: Array<StaticPage>,
 };
 
-
 export type Audience = {
    __typename?: 'Audience',
   id?: Maybe<Scalars['ID']>,
@@ -43,7 +42,6 @@ export type BannerPage = {
   heroBackgroundImageColor?: Maybe<LocalizedObject>,
   heroTopLayerImage?: Maybe<LocalizedCmsImage>,
   socialMediaImage?: Maybe<LocalizedCmsImage>,
-
 };
 
 export type CmsImage = {
@@ -63,6 +61,7 @@ export type CollectionDetails = {
   description?: Maybe<LocalizedObject>,
   draftTitle?: Maybe<Scalars['String']>,
   eventListQuery?: Maybe<LocalizedObject>,
+  courseListQuery?: Maybe<LocalizedObject>,
   eventListTitle?: Maybe<LocalizedObject>,
   expireAt?: Maybe<Scalars['String']>,
   expired?: Maybe<Scalars['Boolean']>,
@@ -778,14 +777,15 @@ export type AccessibilityPagesResponseResolvers<ContextType = any, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-<<<<<<< HEAD
 export type AudienceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Audience'] = ResolversParentTypes['Audience']> = {
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   internalId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   internalContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   internalType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-=======
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type BannerPageResolvers<ContextType = any, ParentType extends ResolversParentTypes['BannerPage'] = ResolversParentTypes['BannerPage']> = {
   title?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
@@ -798,7 +798,6 @@ export type BannerPageResolvers<ContextType = any, ParentType extends ResolversP
   heroBackgroundImageColor?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   heroTopLayerImage?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
   socialMediaImage?: Resolver<Maybe<ResolversTypes['LocalizedCmsImage']>, ParentType, ContextType>;
->>>>>>> bbe37fd... Add top and bottom banner to LandingPage
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -818,6 +817,7 @@ export type CollectionDetailsResolvers<ContextType = any, ParentType extends Res
   description?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   draftTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   eventListQuery?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
+  courseListQuery?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   eventListTitle?: Resolver<Maybe<ResolversTypes['LocalizedObject']>, ParentType, ContextType>;
   expireAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   expired?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
@@ -1203,11 +1203,8 @@ export type SubscriptionResolvers<ContextType = any, ParentType extends Resolver
 export type Resolvers<ContextType = any> = {
   AboutPagesResponse?: AboutPagesResponseResolvers<ContextType>;
   AccessibilityPagesResponse?: AccessibilityPagesResponseResolvers<ContextType>;
-<<<<<<< HEAD
   Audience?: AudienceResolvers<ContextType>;
-=======
   BannerPage?: BannerPageResolvers<ContextType>;
->>>>>>> bbe37fd... Add top and bottom banner to LandingPage
   CmsImage?: CmsImageResolvers<ContextType>;
   CollectionDetails?: CollectionDetailsResolvers<ContextType>;
   CollectionListResponse?: CollectionListResponseResolvers<ContextType>;

--- a/src/utils/normalizeKey.ts
+++ b/src/utils/normalizeKey.ts
@@ -13,6 +13,6 @@ export default (snakecase: string) => {
     str
       .substr(1)
       .toLowerCase()
-      .replace(/(_[a-z])/g, $1 => $1.toUpperCase().replace('_', ''))
+      .replace(/(_[a-z])/g, ($1) => $1.toUpperCase().replace('_', ''))
   );
 };

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -24,7 +24,7 @@ const memoizedNormalizeKey = memoize(normalizeKey);
  *    }
  *  }
  */
-const normalizeKeys = value => {
+const normalizeKeys = (value) => {
   if (Array.isArray(value)) {
     return value.map(normalizeKeys);
   }


### PR DESCRIPTION
New data structure from CMS API where top and bottom banner are added to LandingPage and API will return them as nested objects.
Also added hobbyListQuery to Collection.

_Note: Changes made in CMS API are backward compatible, meaning the old fields still contain old banner data so this PR still contains some deprecated fields left in the typeDef_
![Screenshot 2020-12-11 at 14 30 27](https://user-images.githubusercontent.com/1481118/101903786-79028c80-3bbd-11eb-8a97-82bcfdeb4efa.png)
