### PR TITLE
(wip): TH-918: add new ongoing query parameters

### DIFF
--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -1,4 +1,10 @@
 export const linkedEventsBaseArgs = `
+  localOngoingAnd: [String]
+  localOngoingOr: [String]
+  internetOngoingAnd: [String]
+  internetOngoingOr: [String]
+  allOngoingAnd: [String]
+  allOngoingOr: [String]
   combinedText: [String]
   division: [String]
   end: String

--- a/src/schema/event/utils.ts
+++ b/src/schema/event/utils.ts
@@ -1,10 +1,14 @@
 import { QueryEventListArgs } from '../../types/types';
 import composeQuery from '../../utils/composeQuery';
 import queryBuilder from '../../utils/queryBuilder';
-
 export const buildEventListQuery = (params: QueryEventListArgs) => {
   return queryBuilder([
-    { key: 'combined_text', value: params.combinedText },
+    { key: 'local_ongoing_AND', value: params.localOngoingAnd },
+    { key: 'local_ongoing_OR', value: params.localOngoingOr },
+    { key: 'internet_ongoing_AND', value: params.internetOngoingAnd },
+    { key: 'internet_ongoing_OR', value: params.internetOngoingOr },
+    { key: 'all_ongoing_AND', value: params.allOngoingAnd },
+    { key: 'all_ongoing_OR', value: params.allOngoingOr },
     { key: 'division', value: params.division },
     { key: 'end', value: params.end },
     { key: 'ends_after', value: params.endsAfter },

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -415,6 +415,12 @@ export type QueryEventDetailsArgs = {
 
 
 export type QueryEventListArgs = {
+  localOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  localOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
+  internetOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  internetOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
+  allOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  allOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
   combinedText?: Maybe<Array<Maybe<Scalars['String']>>>,
   division?: Maybe<Array<Maybe<Scalars['String']>>>,
   end?: Maybe<Scalars['String']>,
@@ -459,6 +465,12 @@ export type QueryCourseDetailsArgs = {
 
 
 export type QueryCourseListArgs = {
+  localOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  localOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
+  internetOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  internetOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
+  allOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  allOngoingOr?: Maybe<Array<Maybe<Scalars['String']>>>,
   combinedText?: Maybe<Array<Maybe<Scalars['String']>>>,
   division?: Maybe<Array<Maybe<Scalars['String']>>>,
   end?: Maybe<Scalars['String']>,


### PR DESCRIPTION
## Description :sparkles:

Use `all_ongoing_AND` query parameter instead of `combined_text` on `eventList`. Also support for all other new `*ongoing* `parameters. No changes to `courseList` for now. 

Related events-helsinki-ui PR TBD
## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-918
## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: