### PR TITLE
Make api backwards compatible by reverting combined_text removal

### DIFF
--- a/src/schema/event/utils.ts
+++ b/src/schema/event/utils.ts
@@ -3,6 +3,7 @@ import composeQuery from '../../utils/composeQuery';
 import queryBuilder from '../../utils/queryBuilder';
 export const buildEventListQuery = (params: QueryEventListArgs) => {
   return queryBuilder([
+    { key: 'combined_text', value: params.combinedText },
     { key: 'local_ongoing_AND', value: params.localOngoingAnd },
     { key: 'local_ongoing_OR', value: params.localOngoingOr },
     { key: 'internet_ongoing_AND', value: params.internetOngoingAnd },


### PR DESCRIPTION
## Description :sparkles:
Make api backwards compatible by reverting combined_text removal
## Issues :bug:
TH-981

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: