### PR TITLE
TH-945 | Add error handling tests to event and course resolvers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "eslint.validate": [
     "javascript",
     { "language": "typescript", "autoFix": true }

--- a/src/__tests__/courseIntegration.test.ts
+++ b/src/__tests__/courseIntegration.test.ts
@@ -1,8 +1,20 @@
+/* eslint-disable no-console */
+import * as Sentry from '@sentry/node';
 import { gql } from 'apollo-server';
 
 import CourseAPI from '../datasources/course';
 import { EventDetails, EventListResponse } from '../types/types';
 import { getApolloTestServer } from '../utils/testUtils';
+
+let errorSpy;
+
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error');
+});
+
+afterEach(() => {
+  (console.error as any).mockRestore();
+});
 
 it('resolves eventList correctly', async () => {
   const GET_COURSES = gql`
@@ -99,4 +111,33 @@ it('resolves coursesByIds correctly', async () => {
     { id: 'courseId', publisher: 'publisherId' },
     { id: 'courseId', publisher: 'publisherId' },
   ]);
+});
+
+it('handles error correctly in coursesByIds', async () => {
+  const COURSE_DETAILS = gql`
+    {
+      coursesByIds(ids: ["id1"]) {
+        id
+        publisher
+      }
+    }
+  `;
+
+  const spy = jest.spyOn(Sentry, 'captureException');
+  const errorMessage = 'Error message';
+
+  // avoid error message in test logs
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  errorSpy.mockImplementationOnce(() => {});
+
+  const courseAPI = new CourseAPI();
+  const getMock = jest.fn().mockResolvedValue(Promise.reject(errorMessage));
+  courseAPI.get = getMock;
+
+  const { query } = getApolloTestServer({ dataSources: () => ({ courseAPI }) });
+
+  await query({ query: COURSE_DETAILS });
+
+  expect(spy.mock.calls).toEqual([[errorMessage]]);
+  expect(console.error).toHaveBeenCalled();
 });

--- a/src/schema/course/resolvers.ts
+++ b/src/schema/course/resolvers.ts
@@ -1,4 +1,4 @@
-import Sentry from '@sentry/node';
+import * as Sentry from '@sentry/node';
 
 import { QueryResolvers } from '../../types/types';
 import normalizeKeys from '../../utils/normalizeKeys';


### PR DESCRIPTION
## Description :sparkles:

- Add error handling tests to event and course resolvers

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: