### PR TITLE
Fixed new GRAPHQL_PROXY_API_BASE_URL configuration for all Github envs.

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,9 +35,7 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_PORT: 4000
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_CMS_API_BASE_URL: 'https://cms.prod.kuva.hel.ninja/api/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_EVENTS_API_BASE_PATH: '/linkedevents/v1/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_COURSES_API_BASE_PATH: '/linkedcourses/v1/'
+          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi/linkedevents/v1/'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_MAP_OPEN_DATA_API_BASE_URL: 'https://kartta.hel.fi/ws/geoserver/avoindata'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_DSN: ${{ secrets.GH_SENTRY_DSN }}
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_ENVIRONMENT: 'production'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,9 +29,7 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_PORT: 4000
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_CMS_API_BASE_URL: 'https://cms.test.kuva.hel.ninja/api/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_EVENTS_API_BASE_PATH: '/linkedevents/v1/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_COURSES_API_BASE_PATH: '/linkedcourses/v1/'
+          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi/linkedevents/v1/'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_MAP_OPEN_DATA_API_BASE_URL: 'https://kartta.hel.fi/ws/geoserver/avoindata'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_DSN: ${{ secrets.GH_SENTRY_DSN }}
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_ENVIRONMENT: 'development'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,9 +32,7 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_PORT: 4000
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_CMS_API_BASE_URL: 'https://cms.test.kuva.hel.ninja/api/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_EVENTS_API_BASE_PATH: '/linkedevents/v1/'
-          DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_COURSES_API_BASE_PATH: '/linkedcourses/v1/'
+          DOCKER_BUILD_ARG_GRAPHQL_PROXY_API_BASE_URL: 'https://api.hel.fi/linkedevents/v1/'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_MAP_OPEN_DATA_API_BASE_URL: 'https://kartta.hel.fi/ws/geoserver/avoindata'
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_DSN: ${{ secrets.GH_SENTRY_DSN }}
           DOCKER_BUILD_ARG_GRAPHQL_PROXY_SENTRY_ENVIRONMENT: 'staging'


### PR DESCRIPTION
TH-1132. Removed DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_EVENTS_API_BASE_PATH and DOCKER_BUILD_ARG_GRAPHQL_PROXY_LINKED_COURSES_API_BASE_PATH env variables from review, staging and production. Added the path to GRAPHQL_PROXY_API_BASE_URL.